### PR TITLE
🚧: add JSON schema documents for easier validation of responses

### DIFF
--- a/api/api-parameter-details.md
+++ b/api/api-parameter-details.md
@@ -1095,7 +1095,7 @@ signature = generate_signature(1004, 'createsession', '23DF3C7E9BD14D84BF892AD20
 ## Timestamp
 > string
 
-Current UTC time (GMT+0) in the following format: “**``YYYYMMDDHHmmss``**”.
+Current UTC time (GMT+0) in the following format: “**``yyyyMMddHHmmss``**”.
 
 **Timestamps** are used by [**Signatures**](#signature) and embedded into URLs when sending requests, they have to be formatted properly to ensure the request completes without error.
 
@@ -1130,7 +1130,7 @@ public final String timestamp = get_timestamp();
 ```js
 const moment = require("moment");
 function get_timestamp() {
-  return moment.utc().format("YYYYMMDDHHmmss");
+  return moment.utc().format("yyyyMMddHHmmss");
 }
 var timestamp = get_timestamp();
 ```

--- a/api/create-session/schema.json
+++ b/api/create-session/schema.json
@@ -27,10 +27,11 @@
     },
     "session_id": {
       "type": "string",
-      "minLength": 2
+      "pattern": "\\S+"
     },
     "timestamp": {
-      "type": "string"
+      "type": "string",
+      "pattern": "^(\\d{1,2}\\/\\d{1,2}\\/\\d{4})\\s(0?[1-9]|1[0-2]):([0-5]\\d):([0-5]?\\d)\\s?([APap]\\.?[Mm]\\.?)$"
     }
   },
   "additionalProperties": false

--- a/api/create-session/schema.json
+++ b/api/create-session/schema.json
@@ -19,7 +19,7 @@
   ],
   "properties": {
     "ret_msg": {
-      "type": "string",
+      "type": ["string", "null"],
       "examples": [
         "Approved",
         "Invalid Signature"

--- a/api/create-session/schema.json
+++ b/api/create-session/schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://api.paladins.com/paladinsapi.svc/createsessionjson",
   "type": "object",
   "title": "'create-session' schema",
   "description": "Schema for paladins/realm/smite 'createsessionJSON' endpoint",

--- a/api/create-session/schema.json
+++ b/api/create-session/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
-  "title": "'create-session schema",
+  "title": "'create-session' schema",
   "description": "Schema for paladins/realm/smite 'createsessionJSON' endpoint",
   "default": {},
   "examples": [

--- a/api/create-session/schema.json
+++ b/api/create-session/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "'create-session schema",
+  "description": "Schema for paladins/realm/smite 'createsessionJSON' endpoint",
+  "default": {},
+  "examples": [
+    {
+      "ret_msg": "Approved",
+      "session_id": "4D3064CF27D0473CA4CF142330E97FB5",
+      "timestamp": "11/28/2019 3:09:16 PM"
+    }
+  ],
+  "required": [
+    "ret_msg",
+    "session_id",
+    "timestamp"
+  ],
+  "properties": {
+    "ret_msg": {
+      "type": "string",
+      "examples": [
+        "Approved",
+        "Invalid Signature"
+      ]
+    },
+    "session_id": {
+      "type": "string",
+      "minLength": 2
+    },
+    "timestamp": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/api/get-bounty-items/schema.json
+++ b/api/get-bounty-items/schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "array",
+  "title": "'get-bounty-items' schema",
+  "description": "Schema for paladins 'getbountyitems' endpoint",
+  "minItems": 1,
+  "items": {
+    "type": "object",
+    "properties": {
+      "active": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 1
+      },
+      "bounty_item_id1": {
+        "type": "integer"
+      },
+      "bounty_item_id2": {
+        "type": "integer"
+      },
+      "bounty_item_name": {
+        "type": "string"
+      },
+      "champion_id": {
+        "type": "integer"
+      },
+      "champion_name": {
+        "type": "string"
+      },
+      "final_price": {
+        "type": "string"
+      },
+      "initial_price": {
+        "type": "string"
+      },
+      "ret_msg": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "sale_end_datetime": {
+        "type": "string"
+      },
+      "sale_type": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "active",
+      "bounty_item_id1",
+      "bounty_item_id2",
+      "bounty_item_name",
+      "champion_id",
+      "champion_name",
+      "final_price",
+      "initial_price",
+      "ret_msg",
+      "sale_end_datetime",
+      "sale_type"
+    ]
+  }
+}
+

--- a/api/get-bounty-items/schema.json
+++ b/api/get-bounty-items/schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "array",
   "title": "'get-bounty-items' schema",
-  "description": "Schema for paladins 'getbountyitems' endpoint",
+  "description": "Schema for paladins 'getbountyitemsJSON' endpoint",
   "minItems": 1,
   "items": {
     "type": "object",

--- a/api/get-data-used/schema-realm.json
+++ b/api/get-data-used/schema-realm.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://api.realmroyale.com/realmapi.svc/getdatausedjson",
+  "type": "object",
+  "title": "'get-data-used' schema",
+  "description": "Schema for realmroyale 'getdatausedJSON' endpoint",
+  "default": {},
+  "properties": {
+    "active_sessions": {
+      "type": "integer"
+    },
+    "concurrent_sessions": {
+      "type": "integer"
+    },
+    "request_limit_daily": {
+      "type": "integer"
+    },
+    "session_cap": {
+      "type": "integer"
+    },
+    "session_time_limit": {
+      "type": "integer",
+      "description": "Time in minutes"
+    },
+    "total_requests_today": {
+      "type": "integer"
+    },
+    "total_sessions_today": {
+      "type": "integer"
+    },
+    "ret_msg": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "active_sessions",
+    "concurrent_sessions",
+    "request_limit_daily",
+    "session_cap",
+    "session_time_limit",
+    "total_requests_today",
+    "total_sessions_today",
+    "ret_msg"
+  ],
+  "additionalItems": false
+}

--- a/api/get-data-used/schema.json
+++ b/api/get-data-used/schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://api.paladins.com/paladinsapi.svc/getdatausedjson",
+  "type": "array",
+  "title": "'get-data-used' schema",
+  "description": "Schema for paladins/smite 'getdatausedJSON' endpoint",
+  "minItems": 1,
+  "maxItems": 1,
+  "default": {},
+  "items": {
+    "type": "object",
+    "properties": {
+      "Active_Sessions": {
+        "type": "integer"
+      },
+      "Concurrent_Sessions": {
+        "type": "integer"
+      },
+      "Request_Limit_Daily": {
+        "type": "integer"
+      },
+      "Session_Cap": {
+        "type": "integer"
+      },
+      "Session_Time_Limit": {
+        "type": "integer",
+        "description": "Time in minutes"
+      },
+      "Total_Requests_Today": {
+        "type": "integer"
+      },
+      "Total_Sessions_Today": {
+        "type": "integer"
+      },
+      "ret_msg": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "Active_Sessions",
+      "Concurrent_Sessions",
+      "Request_Limit_Daily",
+      "Session_Cap",
+      "Session_Time_Limit",
+      "Total_Requests_Today",
+      "Total_Sessions_Today",
+      "ret_msg"
+    ]
+  },
+  "additionalItems": false
+}


### PR DESCRIPTION
I am proposing to add a schema document for each endpoint which responds with a JSON document.
I would/will add one global schema for smite/pala/realm if the response schema matches. Otherwise, an extra file for each game will be created.

These schema files would improve the validation of the server responses, because ugly if-blocks could be eliminated. Processing a json-schema should be possible in max. 10 lines.