### PR TITLE
allow file extensions on asset endpoints

### DIFF
--- a/.web/__init__.py
+++ b/.web/__init__.py
@@ -155,9 +155,9 @@ def create_app(*args, **kw):
     #time.ctime(os.path.getatime(path))
 
   #@app.route('/paladins/avatar/<int:avatar_id>/', strict_slashes=False)
-  @app.route('/paladins/avatar/', defaults={'avatar_id': 0}, methods=['GET', 'POST'])
-  @app.route('/paladins/avatar/<avatar_id>', methods=['GET', 'POST'])
-  def legacy_images(avatar_id, game='paladins', folder='avatar'):
+  @app.route('/paladins/avatar/', defaults={'format': '', 'avatar_id': 0}, methods=['GET', 'POST'])
+  @app.route("/paladins/avatar/<avatar_id><any('.gif', '.png', '.jpg', ''):format>", methods=['GET', 'POST'])
+  def legacy_images(avatar_id, format, game='paladins', folder='avatar'):
     path, _avatar_id, _avatars = os.path.join(app.static_folder, game, folder), get_value(request, 'avatar_id', avatar_id), read_file(join_path([get_path(root=True).replace('.web', ''), '.assets', 'paladins', 'avatar', 'avatars.json']))
     if not str(_avatar_id).isnumeric():
       _avatar_id = slugify(_avatar_id)
@@ -205,8 +205,8 @@ def create_app(*args, **kw):
         return send_from_directory(path, _)
 
   @app.route('/<game>/<folder>/', defaults={'file': None}, methods=['GET'])
-  @app.route('/<game>/<folder>/<file>', methods=['GET'])
-  def cdn_(game, folder, file):
+  @app.route("/<game>/<folder>/<file><any('.gif', '.png', '.jpg', ''):format>", methods=['GET'])
+  def cdn_(game, folder, file, format):
     p = path.join(app.static_folder, game, folder)
     if file is not None:
       f = file.rsplit('.', 1)

--- a/.web/__init__.py
+++ b/.web/__init__.py
@@ -156,7 +156,8 @@ def create_app(*args, **kw):
 
   #@app.route('/paladins/avatar/<int:avatar_id>/', strict_slashes=False)
   @app.route('/paladins/avatar/', defaults={'format': '', 'avatar_id': 0}, methods=['GET', 'POST'])
-  @app.route("/paladins/avatar/<avatar_id><any('.gif', '.png', '.jpg', ''):format>", methods=['GET', 'POST'])
+  @app.route("/paladins/avatar/<avatar_id>", defaults={'format': ''}, methods=['GET', 'POST'])
+  @app.route("/paladins/avatar/<avatar_id>.<any('gif', 'png', 'jpg'):format>", methods=['GET', 'POST'])
   def legacy_images(avatar_id, format, game='paladins', folder='avatar'):
     path, _avatar_id, _avatars = os.path.join(app.static_folder, game, folder), get_value(request, 'avatar_id', avatar_id), read_file(join_path([get_path(root=True).replace('.web', ''), '.assets', 'paladins', 'avatar', 'avatars.json']))
     if not str(_avatar_id).isnumeric():
@@ -204,8 +205,9 @@ def create_app(*args, **kw):
           return redirect(url_for('static', filename=f'{game}/{folder}/{_}', _external=True))
         return send_from_directory(path, _)
 
-  @app.route('/<game>/<folder>/', defaults={'file': None}, methods=['GET'])
-  @app.route("/<game>/<folder>/<file><any('.gif', '.png', '.jpg', ''):format>", methods=['GET'])
+  @app.route('/<game>/<folder>/', defaults={'file': None, 'format':''}, methods=['GET'])
+  @app.route("/<game>/<folder>/<file>", defaults={'format':''}, methods=['GET'])
+  @app.route("/<game>/<folder>/<file><any('.gif', '.png', '.jpg':format>")
   def cdn_(game, folder, file, format):
     p = path.join(app.static_folder, game, folder)
     if file is not None:

--- a/.web/__init__.py
+++ b/.web/__init__.py
@@ -155,10 +155,10 @@ def create_app(*args, **kw):
     #time.ctime(os.path.getatime(path))
 
   #@app.route('/paladins/avatar/<int:avatar_id>/', strict_slashes=False)
-  @app.route('/paladins/avatar/', defaults={'avatar_id': 0}, methods=['GET', 'POST'])
-  @app.route("/paladins/avatar/<avatar_id>", methods=['GET', 'POST'])
+  @app.route('/paladins/avatar/', defaults={'format': '', 'avatar_id': 0}, methods=['GET', 'POST'])
+  @app.route("/paladins/avatar/<avatar_id>", defaults={'format': ''}, methods=['GET', 'POST'])
   @app.route("/paladins/avatar/<avatar_id>.<any('gif', 'png', 'jpg'):format>", methods=['GET', 'POST'])
-  def legacy_images(avatar_id, game='paladins', folder='avatar'):
+  def legacy_images(avatar_id, format, game='paladins', folder='avatar'):
     path, _avatar_id, _avatars = os.path.join(app.static_folder, game, folder), get_value(request, 'avatar_id', avatar_id), read_file(join_path([get_path(root=True).replace('.web', ''), '.assets', 'paladins', 'avatar', 'avatars.json']))
     if not str(_avatar_id).isnumeric():
       _avatar_id = slugify(_avatar_id)
@@ -205,10 +205,10 @@ def create_app(*args, **kw):
           return redirect(url_for('static', filename=f'{game}/{folder}/{_}', _external=True))
         return send_from_directory(path, _)
 
-  @app.route('/<game>/<folder>/', defaults={'file': None}, methods=['GET'])
-  @app.route("/<game>/<folder>/<file>", methods=['GET'])
+  @app.route('/<game>/<folder>/', defaults={'file': None, 'format':''}, methods=['GET'])
+  @app.route("/<game>/<folder>/<file>", defaults={'format':''}, methods=['GET'])
   @app.route("/<game>/<folder>/<file><any('.gif', '.png', '.jpg':format>")
-  def cdn_(game, folder, file):
+  def cdn_(game, folder, file, format):
     p = path.join(app.static_folder, game, folder)
     if file is not None:
       f = file.rsplit('.', 1)

--- a/.web/__init__.py
+++ b/.web/__init__.py
@@ -207,7 +207,7 @@ def create_app(*args, **kw):
 
   @app.route('/<game>/<folder>/', defaults={'file': None, 'format':''}, methods=['GET'])
   @app.route("/<game>/<folder>/<file>", defaults={'format':''}, methods=['GET'])
-  @app.route("/<game>/<folder>/<file><any('.gif', '.png', '.jpg':format>")
+  @app.route("/<game>/<folder>/<file>.<any('gif', 'png', 'jpg'):format>")
   def cdn_(game, folder, file, format):
     p = path.join(app.static_folder, game, folder)
     if file is not None:

--- a/.web/__init__.py
+++ b/.web/__init__.py
@@ -155,10 +155,10 @@ def create_app(*args, **kw):
     #time.ctime(os.path.getatime(path))
 
   #@app.route('/paladins/avatar/<int:avatar_id>/', strict_slashes=False)
-  @app.route('/paladins/avatar/', defaults={'format': '', 'avatar_id': 0}, methods=['GET', 'POST'])
-  @app.route("/paladins/avatar/<avatar_id>", defaults={'format': ''}, methods=['GET', 'POST'])
+  @app.route('/paladins/avatar/', defaults={'avatar_id': 0}, methods=['GET', 'POST'])
+  @app.route("/paladins/avatar/<avatar_id>", methods=['GET', 'POST'])
   @app.route("/paladins/avatar/<avatar_id>.<any('gif', 'png', 'jpg'):format>", methods=['GET', 'POST'])
-  def legacy_images(avatar_id, format, game='paladins', folder='avatar'):
+  def legacy_images(avatar_id, game='paladins', folder='avatar'):
     path, _avatar_id, _avatars = os.path.join(app.static_folder, game, folder), get_value(request, 'avatar_id', avatar_id), read_file(join_path([get_path(root=True).replace('.web', ''), '.assets', 'paladins', 'avatar', 'avatars.json']))
     if not str(_avatar_id).isnumeric():
       _avatar_id = slugify(_avatar_id)
@@ -205,10 +205,10 @@ def create_app(*args, **kw):
           return redirect(url_for('static', filename=f'{game}/{folder}/{_}', _external=True))
         return send_from_directory(path, _)
 
-  @app.route('/<game>/<folder>/', defaults={'file': None, 'format':''}, methods=['GET'])
-  @app.route("/<game>/<folder>/<file>", defaults={'format':''}, methods=['GET'])
+  @app.route('/<game>/<folder>/', defaults={'file': None}, methods=['GET'])
+  @app.route("/<game>/<folder>/<file>", methods=['GET'])
   @app.route("/<game>/<folder>/<file><any('.gif', '.png', '.jpg':format>")
-  def cdn_(game, folder, file, format):
+  def cdn_(game, folder, file):
     p = path.join(app.static_folder, game, folder)
     if file is not None:
       f = file.rsplit('.', 1)


### PR DESCRIPTION
This PR enables the user to use file extensions while querying https://hirez-api.onrender.com.

## Solves the following:

- The default file is shown, when using an extension despite `/assets` returning the filename with extension.
- Reduces the hastle involved to support applications requiring certain externsions to view or playback media. (e.g. discord: requires the .gif extension to playback gifs)

(
- Discontinues my own cdn proxy, which only job was to cache and add fileextensions 😄   

)

Please review and give feedback on this change.
PS: I've added you(@luissilva1044894) on discord ;)
